### PR TITLE
fixing equations (no katex) and camera links

### DIFF
--- a/hardware/antennas.md
+++ b/hardware/antennas.md
@@ -39,21 +39,21 @@ The below link explains how the video quality is impacted under different scenar
 
 A typical question is related to the maximum range, link budget or system range have relation to three main elements: Transmitter power, Antenna gains, and Receiver sensitivity. The next formula can be used to calculate this:
 
-$\qquad \Huge{R = 10^{\frac{RF_{HW} - LM - 32.44 - 20*log_{10}(f)}{20}}}$  
+`R_km = 10 ^ ( ( RF_HW - LM - 32.44 - 20*log10(f_MHz) ) / 20 )`
 
-$\qquad \large{RF_{HW} = P_{TX} + G_{TX} + G_{RX} - S_{RX}}$  
+`RF_HW = P_TX + G_TX + G_RX - S_RX`
 
 where:
 
-$\quad R \textnormal{ is the transmission range in km}$  
-$\quad f \textnormal{ is the frequency in MHz}$  
-$\quad LM \textnormal{ is the desired system Link Margin in dB}$  
-$\quad 32.44 \textnormal{ is the Friis constant for solving with units of km and MHz above}$  
-$\quad RF_{HW} \textnormal{ represents the RF Hardware (Radio / Antenna) parameters in dB}$  
-$\quad P_{TX} \textnormal{ is the Tx power in dBm}$  
-$\quad G_{TX} \textnormal{ is the Tx antenna gain in dBi}$  
-$\quad G_{RX} \textnormal{ is the Rx antenna gain in dBi}$  
-$\quad S_{RX} \textnormal{ is the Rx Sensitivity in dBm}$  
+`R_km` is the transmission range in km
+`f_MHz` is the frequency in MHz
+`LM` is the desired system Link Margin in dB
+`32.44` is the Friis constant for solving with units of km and MHz above
+`RF_HW` represents the RF Hardware (Radio / Antenna) parameters in dB
+`P_TX` is the Tx power in dBm
+`G_TX` is the Tx antenna gain in dBi
+`G_RX` is the Rx antenna gain in dBi
+`S_RX` is the Rx Sensitivity in dBm
 
 | Ground Side antenna / Gain | Air Side antenna / Gain | Frequency GHz | Power TX mW | Theoretical range Km \* | Notes |
 | :--- | :--- | :--- | :--- | :--- | :--- |

--- a/hardware/custom-cameras.md
+++ b/hardware/custom-cameras.md
@@ -6,4 +6,4 @@ The custom cameras will be optimized for use in drone racing and aerial videogra
 
 The OpenHD custom hardware project is currently in development, and prototypes are being tested and refined to ensure optimal performance and reliability. As the project progresses, the team will be working to create a final version of the cameras that meets the needs of drone racing and aerial videography enthusiasts.
 
-If you would like to learn more about this project and stay up-to-date on its progress, be sure to visit (https://www.patreon.com/OpenHD)[https://www.patreon.com/OpenHD]. The team is always looking for new supporters and contributors to help bring this exciting project to life.
+If you would like to learn more about this project and stay up-to-date on its progress, be sure to visit [https://www.patreon.com/OpenHD](https://www.patreon.com/OpenHD). The team is always looking for new supporters and contributors to help bring this exciting project to life.

--- a/hardware/custom-hardware.md
+++ b/hardware/custom-hardware.md
@@ -1,6 +1,6 @@
 # Custom Hardware
 
-OpenHD custom hardware is an ongoing project that is currently being developed and funded through (https://www.patreon.com/OpenHD)[https://www.patreon.com/OpenHD]. The project aims to create a small and modular wireless high-definition video transmission system that is capable of transmitting and recording video in various resolutions and framerates with low latency capabilities.
+OpenHD custom hardware is an ongoing project that is currently being developed and funded through [https://www.patreon.com/OpenHD](https://www.patreon.com/OpenHD). The project aims to create a small and modular wireless high-definition video transmission system that is capable of transmitting and recording video in various resolutions and framerates with low latency capabilities.
 
 The system is specifically designed to fit into the standard 30.5x30.5mm FPV drone stack system, making it easy to integrate into existing drone setups. 
 
@@ -8,4 +8,4 @@ The project team is currently working on refining the design and improving its p
 
 It's worth noting that the OpenHD custom hardware project has already progressed beyond the conceptual stage and the team has developed several prototypes. These prototypes are currently being tested and refined.
 
-If you would like to learn more about this project and stay up-to-date on its progress, be sure to visit (https://www.patreon.com/OpenHD)[https://www.patreon.com/OpenHD]. The team is always looking for new supporters and contributors to help bring this exciting project to life.
+If you would like to learn more about this project and stay up-to-date on its progress, be sure to visit [https://www.patreon.com/OpenHD](https://www.patreon.com/OpenHD). The team is always looking for new supporters and contributors to help bring this exciting project to life.

--- a/hardware/special-camera.md
+++ b/hardware/special-camera.md
@@ -48,11 +48,11 @@ Another consideration is the thermal "span" of the area in view of the thermal c
 
 **FLIR Tau 2 and range test**
 
-[![FLIR Tau 2 flight](https://github.com/OpenHD/OpenHD/blob/fc9d050b3d8d9bc2493895b558ee2f13f6ec15b1/wiki-content/Thermal-Cameras/flir-tau-2-flight-screenshot.jpg)](https://www.youtube.com/watch?v=WXKOqgxwp-c)
+[![FLIR Tau 2 flight](https://github.com/OpenHD/OpenHD/blob/fc9d050b3d8d9bc2493895b558ee2f13f6ec15b1/wiki-content/Thermal-Cameras/flir-tau-2-flight-screenshot.jpg?raw=true)](https://www.youtube.com/watch?v=WXKOqgxwp-c)
 
 **FLIR Boson 320 flight over a neighborhood**
 
-[![FLIR Boson 320 flight](https://github.com/OpenHD/OpenHD/blob/fc9d050b3d8d9bc2493895b558ee2f13f6ec15b1/wiki-content/Thermal-Cameras/flir-boson-320-flight.jpg)](https://www.youtube.com/watch?v=PQGDQzf-Z50)
+[![FLIR Boson 320 flight](https://github.com/OpenHD/OpenHD/blob/fc9d050b3d8d9bc2493895b558ee2f13f6ec15b1/wiki-content/Thermal-Cameras/flir-boson-320-flight.jpg)](https://www.youtube.com/watch?v=PQGDQzf-Z50?raw=true)
 
 ### Lenses
 
@@ -70,7 +70,7 @@ In some cases a thermal camera may require a different SBC, a video adapter of s
 
 #### FLIR One G2
 
-![flir one g2](https://github.com/OpenHD/OpenHD/blob/fc9d050b3d8d9bc2493895b558ee2f13f6ec15b1/wiki-content/Thermal-Cameras/flir-one-g2.jpeg)
+![flir one g2](https://github.com/OpenHD/OpenHD/blob/fc9d050b3d8d9bc2493895b558ee2f13f6ec15b1/wiki-content/Thermal-Cameras/flir-one-g2.jpeg?raw=true)
 
 These are designed to connect to a smartphone, there were iOS and Android versions with different connectors. The Android version has a standard Micro USB connector and can be connected to an OpenHD system with a USB OTG cable.
 
@@ -96,7 +96,7 @@ These are cheap, but have always had significant issues due to the lens and the 
 
 #### Seek Compact Pro \([manufacturer](https://www.thermal.com/compact-series.html), [Amazon](https://www.amazon.com/Seek-Thermal-CompactPRO-Resolution-Imaging/dp/B07V34RFLW)\)
 
-![Seek Compact Pro compared to Flir One G2](https://github.com/OpenHD/OpenHD/blob/fc9d050b3d8d9bc2493895b558ee2f13f6ec15b1/wiki-content/Thermal-Cameras/seek-compact-pro-compare.jpeg)
+![Seek Compact Pro compared to Flir One G2](https://github.com/OpenHD/OpenHD/blob/fc9d050b3d8d9bc2493895b558ee2f13f6ec15b1/wiki-content/Thermal-Cameras/seek-compact-pro-compare.jpeg?raw=true)
 
 Model numbers for these cameras _do not_ end with an X, e.g. UQ-AAA.
 
@@ -116,7 +116,7 @@ These are export controlled items because of the frame rate, you can buy them ea
 
 #### Hti-201 \([manufacturer](https://hti-instrument.com/products/ht-201-mobile-phone-thermal-imager)\)
 
-![Hti-201 Thermal Camera](https://github.com/OpenHD/OpenHD/blob/fc9d050b3d8d9bc2493895b558ee2f13f6ec15b1/wiki-content/Thermal-Cameras/hti-201.jpg)
+![Hti-201 Thermal Camera](https://github.com/OpenHD/OpenHD/blob/fc9d050b3d8d9bc2493895b558ee2f13f6ec15b1/wiki-content/Thermal-Cameras/hti-201.jpg?raw=true)
 
 These are basically clones of the Seek Compact Pro.
 
@@ -124,7 +124,7 @@ The camera housing has a very awkward shape compared to most other thermal camer
 
 #### Hti-301 \([manufacturer](https://hti-instrument.com/products/ht-301-mobile-phone-thermal-imager), [Amazon](https://www.amazon.com/Resolution-Infrared-Thermal-Smartphone-Hti-Xintai/dp/B07Z7J6LXD)\)
 
-![Hti-301 Thermal Camera](https://github.com/OpenHD/OpenHD/blob/fc9d050b3d8d9bc2493895b558ee2f13f6ec15b1/wiki-content/Thermal-Cameras/hti-301.jpg)
+![Hti-301 Thermal Camera](https://github.com/OpenHD/OpenHD/blob/fc9d050b3d8d9bc2493895b558ee2f13f6ec15b1/wiki-content/Thermal-Cameras/hti-301.jpg?raw=true)
 
 A very good thermal camera with 384x288 resolution and a fairly large germanium lens and a frame rate of 25hz. They are expensive compared to some others, but the thermal performance is very good.
 
@@ -134,7 +134,7 @@ Note that you may have trouble getting 25hz video streams out of these when used
 
 #### FLIR Boson 320 \([manufacturer](https://www.flir.com/products/boson/), [GroupGets](https://store.groupgets.com/collections/frontpage/products/flir-boson-320)\)
 
-![FLIR Boson 320 Thermal Core](https://github.com/OpenHD/OpenHD/blob/fc9d050b3d8d9bc2493895b558ee2f13f6ec15b1/wiki-content/Thermal-Cameras/flir-boson-320.jpg)
+![FLIR Boson 320 Thermal Core](https://github.com/OpenHD/OpenHD/blob/fc9d050b3d8d9bc2493895b558ee2f13f6ec15b1/wiki-content/Thermal-Cameras/flir-boson-320.jpg?raw=true)
 
 A 320x256 thermal imager "core", full 60hz frame rate but FLIR makes a 9hz version as well. They are fairly expensive but have Germanium lenses.
 
@@ -146,7 +146,7 @@ These are export controlled items due to the very high frame rate.
 
 Real world flight video:
 
-[![FLIR Boson 320 flight](https://github.com/OpenHD/OpenHD/blob/fc9d050b3d8d9bc2493895b558ee2f13f6ec15b1/wiki-content/Thermal-Cameras/flir-boson-320-flight.jpg)](https://www.youtube.com/watch?v=PQGDQzf-Z50)
+[![FLIR Boson 320 flight](https://github.com/OpenHD/OpenHD/blob/fc9d050b3d8d9bc2493895b558ee2f13f6ec15b1/wiki-content/Thermal-Cameras/flir-boson-320-flight.jpg?raw=true)](https://www.youtube.com/watch?v=PQGDQzf-Z50)
 
 #### FLIR Boson 640 \([manufacturer](https://www.flir.com/products/boson/), [GroupGets](https://store.groupgets.com/collections/frontpage/products/flir-boson-640)\)
 


### PR DESCRIPTION
Fixing equation issues introduced in #26 because there is no KaTeX module available in the OpenHD instance of GitBook, also tries to fix camera links (again) and fixes incorrect use of []/() for patreon custom hardware links.